### PR TITLE
add unoffical Kosovo

### DIFF
--- a/dictionary/data_iso.csv
+++ b/dictionary/data_iso.csv
@@ -118,6 +118,7 @@ Kenya,Kenya (le),KE,KEN,404,Kenya
 Kiribati,Kiribati,KI,KIR,296,Kiribati
 Korea (the Democratic People's Republic of),Corée (la République populaire démocratique de),KP,PRK,408,Korea (the Democratic People's Republic of)
 Korea (the Republic of),Corée (la République de),KR,KOR,410,Korea (the Republic of)
+Kosovo (Republic of),,XK,XKX,,Kosovo (Republic of)
 Kuwait,Koweït (le),KW,KWT,414,Kuwait
 Kyrgyzstan,Kirghizistan (le),KG,KGZ,417,Kyrgyzstan
 Lao People's Democratic Republic (the),Lao (la République démocratique populaire),LA,LAO,418,Lao People's Democratic Republic (the)


### PR DESCRIPTION
as used by the European Commission and others until Kosovo is assigned an ISO code.